### PR TITLE
Import unistd.h before calling `syscall`.

### DIFF
--- a/src/syscalls.h
+++ b/src/syscalls.h
@@ -19,6 +19,7 @@
 #ifndef __SYSCALLS_H__
 #define __SYSCALLS_H__
 
+#include <unistd.h>
 #include <sys/syscall.h>
 
 static inline int _tgkill(int tgid, int tid, int sig)


### PR DESCRIPTION
The Linux man page for syscall(2) documents it as:

```
#define _GNU_SOURCE         /* See feature_test_macros(7) */
#include <unistd.h>
#include <sys/syscall.h>   /* For SYS_xxx definitions */

long syscall(long number, ...);
```

Therefore unistd.h is required in addition to the already imported
sys/syscall.h and the already defined _GNU_SOURCE.