### PR TITLE
Mark `dlsym` with `__attribute__((noinline))`.

### DIFF
--- a/src/dso_signal.c
+++ b/src/dso_signal.c
@@ -203,7 +203,7 @@ static void protect_sigsegv_cpuid_handler(void)
 extern void *_dl_sym (void *handle, const char *name, void *who);
 
 static void *(*real_dlsym)(void *handle, const char *symbol);
-LIB_EXPORT
+LIB_EXPORT __attribute__((noinline))
 void *dlsym(void *handle, const char *symbol)
 {
     if (!real_dlsym) {


### PR DESCRIPTION
In some circumstances (e.g. under higher optimization modes when
compiled with LLVM), `dlsym` gets inlined into `libvirtcpuid_init_dso`.

When this happens, dlsym's use of `__builtin_return_address(0)` no
longer returns the address of `dlsym` and instead returns the address of
`libvirtcpuid_init_dso`. When that happens, `_dl_sym` fails to find the
next `dlsym` and the process crashes.