### PR TITLE
Correctly handle when arch_prctl fails.

### DIFF
--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -364,7 +364,7 @@ void cpuid_init(bool secure)
     if (!strcmp(conf, "help"))
         show_help_and_die();
 
-    bool faulting_disabled;
+    int faulting_disabled;
     if ((faulting_disabled = arch_prctl(ARCH_GET_CPUID, 0)) < 0)
         secure_err(1, "CPUID faulting feature inaccessible");
 


### PR DESCRIPTION
The current code is written as follows:

```
bool faulting_disabled;
if ((faulting_disabled = arch_prctl(ARCH_GET_CPUID, 0)) < 0)
    secure_err(1, "CPUID faulting feature inaccessible");
```

`arch_prctl` will return -1 on failure, however bool cannot represent
the value -1. This produces the following warning in clang when
`-Wtautological-constant-compare` is enabled)

```
third_party/libvirtcpuid/src/cpuid.c:368:61: error: result of comparison of constant 0 with expression of type 'bool' is always false [-Werror,-Wtautological-constant-compare]
    if ((faulting_disabled = arch_prctl(ARCH_GET_CPUID, 0)) < 0)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
```

The fix is to change `faulting_disabled` to an int so it can store the
return value of `arch_prctl`.