### PR TITLE
Support modification of the CPU brand/model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ musl: $(MUSL_ARCHIVE)
 	mv musl.tmp musl
 
 musl/lib/libc.a: musl
-	cd musl && ./configure --disable-shared
+	cd musl && CFLAGS=-fPIC ./configure --disable-shared
 	+make -C musl
 
 $(TARGET_LD): $(OBJECTS_LD) musl/lib/libc.a

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ examples describe some typical issues encountered without CPUID virtualization:
   We can use `libvirtcpuid` to make CPUID report a larger XSAVE area on the
   original host to ensure successful migration to hosts with larger XSAVE areas.
 
+* Suppose an operating system requires a certain processor model even though it
+  will work fine with older CPU models.
+
 ## Usage
 
 ### Compilation
@@ -70,6 +73,7 @@ compilation with `make INTERPOSED_LD_PATH=/path/to/ld-orig.so`.
 ```bash
 LD_PRELOAD=/path/to/libvirtcpuid.so
 VIRT_CPUID_MASK=avx512f,hle,rtm,xsavearea=2696
+VIRT_CPUID_BRAND='My Fake CPU Model'
 ```
 
 Note that the path of the injected environment variables can be configured during
@@ -97,6 +101,7 @@ patchelf --set-interpreter /path/to/ld-virtcpuid.so /path/to/some-program
 If the two previous options are not possible, run your program with:
 
 ```bash
+export VIRT_CPUID_BRAND='My Fake CPU Model'
 LD_PRELOAD=/path/to/libvirtcpuid.so VIRT_CPUID_MASK=avx512f,hle,rtm,xsavearea=2696 some-program
 ```
 

--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -258,6 +258,20 @@ static void virtualize_cpuid(uint32_t leaf, uint32_t subleaf, struct cpuid_regs 
         regs->ecx = xsavearea_size;
     }
 
+	/* Virtualize the CPUID brand string */
+	char *envmodel = getenv("VIRT_CPUID_BRAND");
+	if (envmodel != NULL && leaf >= 0x80000002 && leaf <= 0x80000004)
+	{
+		static char model[12*4+1] = {0};
+		strncpy(model, envmodel, 12*4);
+
+		uint32_t offset = (leaf-0x80000002)*16;
+		memcpy(&regs->eax, model+offset+0, 4);
+		memcpy(&regs->ebx, model+offset+4, 4);
+		memcpy(&regs->ecx, model+offset+8, 4);
+		memcpy(&regs->edx, model+offset+12, 4);
+	}
+
     for (i = get_next_matching_leaf_index(leaf, subleaf, 0); i >= 0;
          i = get_next_matching_leaf_index(leaf, subleaf, i+1)) {
         switch (reverse_cpuid[i].reg) {


### PR DESCRIPTION
The CPU brand register can now be configured by setting `VIRT_CPUID_BRAND` as an environment variable:

    export VIRT_CPUID_BRAND=foomodel
    LD_PRELOAD=/path/to/libvirtcpuid.so /some/program

Note:

This commit also adds `-fPIC` to the MUSL build so it will compile without the "needs -fPIC" error.